### PR TITLE
Make transitions selectable.

### DIFF
--- a/src/components/graph/ModuleGraph.css
+++ b/src/components/graph/ModuleGraph.css
@@ -41,6 +41,14 @@
   stroke: #CCC;
 }
 
+.transition path{
+  cursor: pointer;
+}
+
+.transition text{
+  cursor: pointer;
+}
+
 .transition.transition-highlighted path {
   stroke: #336699;
   stroke-width: 3px;

--- a/src/components/graph/ModuleGraph.js
+++ b/src/components/graph/ModuleGraph.js
@@ -102,6 +102,18 @@ class ModuleGraph extends Component<Props> {
       }
     })
 
+    document.querySelectorAll('.edge.transition').forEach( group => {
+      let originator = group.querySelector('title').innerHTML.split('-&gt;')[0]
+      let hitLine = group.querySelector('path').cloneNode(true)
+      hitLine.setAttribute('stroke-width', 20)
+      hitLine.setAttribute('opacity', 0)
+      group.appendChild(hitLine)
+
+      group.querySelectorAll('path,text').forEach( path => {
+        path.addEventListener('mouseup', (e) => {e.stopPropagation(); this.props.onClick(originator)});
+      })
+    })
+
     /* add pan/zoom if available */
     if(typeof svgPanZoom === "function"){
 


### PR DESCRIPTION
Fixes #54 

Note: I added in a larger 'hitbox' behind the transitions, because trying to just select the skinny line is hard.  I don't think this will cause problems, but it adds a little complexity.