### PR TITLE
Prior state fix

### DIFF
--- a/src/components/editor/ComplexTransition.js
+++ b/src/components/editor/ComplexTransition.js
@@ -36,7 +36,9 @@ class ComplexTransition extends Component<Props> {
         Complex Transition:
         {currentValue.map((t, i) => {
           return <div className='transition-option' key={i}>
-            <label>If: <ConditionalEditor conditional={t.condition} onChange={this.props.onChange(`[${i}].condition`)}/></label>
+            <label>
+              If: <ConditionalEditor {...this.props} conditional={t.condition} onChange={this.props.onChange(`${i}.condition`)}/>
+            </label>
             <label>
               <DistributedTransitionEditor transition={{transition: t.distributions}} options={states} onChange={this.props.onChange(`[${i}].distributions`)} />
             </label>

--- a/src/components/editor/Conditional.js
+++ b/src/components/editor/Conditional.js
@@ -9,7 +9,7 @@ import { AttributeTemplates, TypeTemplates } from '../../templates/Templates';
 
 type Props = {
   conditional: Conditional,
-  otherStates: State[],
+  options: State[],
   onChange: any
 }
 
@@ -279,7 +279,7 @@ class PriorState extends Component<Props> {
 
   render() {
     let conditional = ((this.props.conditional: any): PriorStateConditional);
-    let options = this.props.otherStates.map((s) => {return {id: s.name, text: s.name}});
+    let options = this.props.options.map((s) => {return {id: s.name, text: s.name}});
     let name = conditional.name;
     return (
       <label>
@@ -301,7 +301,7 @@ class PriorState extends Component<Props> {
         </label>
       );
     } else {
-      let options = this.props.otherStates.map((s) => {return {id: s.name, text: s.name}});
+      let options = this.props.options.map((s) => {return {id: s.name, text: s.name}});
       let since = conditional.since;
       return (
         <label>
@@ -327,7 +327,8 @@ class PriorState extends Component<Props> {
           Prior State Within Quantity: <RIENumber className='editable-text' value={conditional.within.quantity} propName="quantity" change={this.props.onChange('within.quantity')} />
           <br />
           Prior State Within Unit: <RIESelect className='editable-text' value={{id: conditional.within.unit, text: conditional.within.unit}} propName="unit" change={this.props.onChange('within.unit')} options={unitOfTimeOptions} />
-          <a className='editable-text' onClick={() => this.props.onChange('within')({val: {id: null}})}> (remove)</a>
+          <br />
+          <a className='editable-text' onClick={() => this.props.onChange('within')({val: {id: null}})}>Remove Within</a>
         </label>
       );
     }

--- a/src/components/editor/Conditional.js
+++ b/src/components/editor/Conditional.js
@@ -1,14 +1,27 @@
 // @flow
 import React, { Component } from 'react';
 import { RIESelect, RIEInput, RIENumber } from 'riek';
+import _ from 'lodash';
 import type { Conditional, GenderConditional , AgeConditional , DateConditional , SocioeconomicStatusConditional , RaceConditional , SymptomConditional , ObservationConditional , VitalSignConditional , ActiveConditionConditional , ActiveMedicationConditional , ActiveCarePlanConditional , PriorStateConditional , AttributeConditional , AndConditional , OrConditional , AtLeastConditional , AtMostConditional , NotConditional } from '../../types/Conditional';
+import type { State } from '../../types/State';
 import { Codes } from './Code';
-import {TypeTemplates} from '../../templates/Templates';
+import { AttributeTemplates, TypeTemplates } from '../../templates/Templates';
 
 type Props = {
   conditional: Conditional,
+  otherStates: State[],
   onChange: any
 }
+
+const unitOfTimeOptions = [
+  {id: 'years', text: 'years'},
+  {id: 'months', text: 'months'},
+  {id: 'weeks', text: 'weeks'},
+  {id: 'days', text: 'days'},
+  {id: 'hours', text: 'hours'},
+  {id: 'minutes', text: 'minutes'},
+  {id: 'seconds', text: 'seconds'}
+];
 
 const unitOfAgeOptions = [
   {id: 'years', text: 'years'},
@@ -46,7 +59,7 @@ class ConditionalEditor extends Component<Props> {
         return <ActiveMedication {...this.props} />
       case "Active CarePlan":
         return <ActiveCarePlan {...this.props} />
-      case "Prior State":
+      case "PriorState":
         return <PriorState {...this.props} />
       case "Attribute":
         return <Attribute {...this.props} />
@@ -266,14 +279,58 @@ class PriorState extends Component<Props> {
 
   render() {
     let conditional = ((this.props.conditional: any): PriorStateConditional);
-
     let options = this.props.otherStates.map((s) => {return {id: s.name, text: s.name}});
-    let name = conditional.name === " "? "(none)" : conditional.name;
+    let name = conditional.name;
     return (
-      <label> PriorState:
-        <RIESelect className='editable-text' value={{id: name , text: name}} propName="name" change={this.props.onChange('name')} options={options} />
+      <label>
+        Prior State Name: <RIESelect className='editable-text' value={{id: name, text: name}} propName="name" change={this.props.onChange('name')} options={options} />
+        <br />
+        {this.renderSince()}
+        <br />
+        {this.renderWithin()}
       </label>
     );
+  }
+
+  renderSince() {
+    let conditional = ((this.props.conditional: any): PriorStateConditional);
+    if (conditional.since == null) {
+      return (
+        <label>
+          <a className='editable-text' onClick={() => this.props.onChange('since')({val: {id: _.cloneDeep(AttributeTemplates.Since)}})}>Add Since</a>
+        </label>
+      );
+    } else {
+      let options = this.props.otherStates.map((s) => {return {id: s.name, text: s.name}});
+      let since = conditional.since;
+      return (
+        <label>
+          Prior State Since: <RIESelect className='editable-text' value={{id: since, text: since}} propName="since" change={this.props.onChange('since')} options={options} />
+          <a className='editable-text' onClick={() => this.props.onChange('since')({val: {id: null}})}> (remove)</a>
+        </label>
+      );
+    }
+  }
+
+  renderWithin() {
+    let conditional = ((this.props.conditional: any): PriorStateConditional);
+    if (conditional.within == null) {
+      return (
+        <label>
+          <a className='editable-text' onClick={() => this.props.onChange('within')({val: {id: _.cloneDeep(AttributeTemplates.Within)}})}>Add Within</a>
+          <br />
+        </label>
+      );
+    } else {
+      return (
+        <label>
+          Prior State Within Quantity: <RIENumber className='editable-text' value={conditional.within.quantity} propName="quantity" change={this.props.onChange('within.quantity')} />
+          <br />
+          Prior State Within Unit: <RIESelect className='editable-text' value={{id: conditional.within.unit, text: conditional.within.unit}} propName="unit" change={this.props.onChange('within.unit')} options={unitOfTimeOptions} />
+          <a className='editable-text' onClick={() => this.props.onChange('within')({val: {id: null}})}> (remove)</a>
+        </label>
+      );
+    }
   }
 
 }

--- a/src/components/editor/ConditionalTransition.js
+++ b/src/components/editor/ConditionalTransition.js
@@ -32,10 +32,11 @@ class ConditionalTransition extends Component<Props> {
         {currentValue.map((t, i) => {
           let options = this.props.options.map((s) => {return {id: s.name, text: s.name}});
           return <div key={i} className='transition-option'>
-            <label>If: <ConditionalEditor {...this.props} conditional={t.condition} onChange={this.props.onChange(`${i}.condition`)}/></label>
-            <label>Transition To:
-              <RIESelect className='editable-text' propName='to' value={{id:t.to, text:t.to}} change={this.props.onChange(`${i}.transition`)} options={options} />
-
+            <label>
+              If: <ConditionalEditor {...this.props} conditional={t.condition} onChange={this.props.onChange(`${i}.condition`)}/>
+            </label>
+            <label>
+              Transition To: <RIESelect className='editable-text' propName='to' value={{id:t.to, text:t.to}} change={this.props.onChange(`${i}.transition`)} options={options} />
             </label>
             <br/>
             <a className="editable-text delete-button" onClick={() => this.props.onChange(`[${i}]`)({val: {id: null}})}>remove</a>

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -195,7 +195,7 @@ class Guard extends Component<Props> {
     let state = ((this.props.state: any): GuardState);
     return (
       <div>
-        <ConditionalEditor {...this.props} conditional={state.allow} onChange={this.props.onChange('allow')} />
+        <ConditionalEditor {...this.props} conditional={state.allow} options={this.props.otherStates} onChange={this.props.onChange('allow')} />
       </div>
     );
   }

--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -98,9 +98,9 @@ export const TypeTemplates = {
         }
       ]
     },
-    "Prior State": {
-      "condition_type": "Prior State",
-      "name": " "
+    PriorState: {
+      "condition_type": "PriorState",
+      "name": ""
     },
     Attribute: {
       "condition_type": "Attribute",
@@ -243,6 +243,11 @@ export const AttributeTemplates = {
     codes: [{...TypeTemplates.Code.Loinc}],
     operator: "==",
     value: 1
+  },
+  Since: " ",
+  Within: {
+    quantity: 1,
+    unit: "days"
   },
   UnnamedDistribution: 1.0,
   NamedDistribution: {

--- a/src/types/Conditional.js
+++ b/src/types/Conditional.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { Code } from './Code';
-import type { UnitOfAge } from './Units';
+import type { UnitOfTime, UnitOfAge } from './Units';
 
 export type GenderConditional = {
   condition_type: 'Gender',
@@ -69,9 +69,13 @@ export type ActiveCarePlanConditional = {
 }
 
 export type PriorStateConditional = {
-  condition_type: 'Prior State',
+  condition_type: 'PriorState',
   name: string,
-  since: string
+  since?: string,
+  within?: {
+    quantity: number,
+    unit: UnitOfTime
+  }
 }
 
 export type AttributeConditional = {

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -413,7 +413,6 @@ const logicDetails = logic => {
     case 'Symptom':
       return `Symptom: '${logic['symptom']}' \\${logic['operator']} ${logic['value']}\\l`
     case 'PriorState':
-      let within_logic = null;
       let prior_description = `state '${logic['name']}' has been processed`
       if(logic.since !== undefined){
         prior_description = `${prior_description} since ${logic.since}`

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -413,11 +413,15 @@ const logicDetails = logic => {
     case 'Symptom':
       return `Symptom: '${logic['symptom']}' \\${logic['operator']} ${logic['value']}\\l`
     case 'PriorState':
-      if(logic.within !== undefined){
-        return `state '${logic['name']}' has been processed within ${logic.within['quantity']} ${logic.within['unit']}\\l`
-      } else {
-        return `state '${logic['name']}' has been processed\\l`
+      let within_logic = null;
+      let prior_description = `state '${logic['name']}' has been processed`
+      if(logic.since !== undefined){
+        prior_description = `${prior_description} since ${logic.since}`
       }
+      if(logic.within !== undefined){
+        prior_description = `${prior_description} within ${logic.within['quantity']} ${logic.within['unit']}`
+      }
+      return `${prior_description} \\l`
     case 'Attribute':
       return `Attribute: '${logic['attribute']}' \\${logic['operator']} ${logic['value']}\\l`
     case 'Observation':


### PR DESCRIPTION
The `PriorState` conditional had some bugs when being used in transitions. Additionally, it did not have the `since` and `within` attributes implemented yet in the editor. This PR addresses those issues.

Fixes #116.