### PR TITLE
Remove BOM on download since it causes issues in synthea on windows

### DIFF
--- a/src/components/menu/Download.js
+++ b/src/components/menu/Download.js
@@ -18,7 +18,7 @@ class Download extends Component {
 
     let filename = this.props.module.name.replace(/[^a-z0-9]/gi, '_').toLowerCase();
 
-    FileSaver.saveAs(blob, `${filename}.json`);
+    FileSaver.saveAs(blob, `${filename}.json`, true); // true = no BOM, see https://github.com/eligrey/FileSaver.js/issues/160
   }
 
   prepareJSON(){


### PR DESCRIPTION
Sets a flag so that downloaded modules are saved without the byte order mark. The BOM seems to cause issues in Synthea on Windows, even though it works fine on Mac OS and Travis.