### PR TITLE
Add ImagingStudy State to Module Builder

### DIFF
--- a/src/components/editor/Code.js
+++ b/src/components/editor/Code.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
-import { RIESelect, RIEInput, RIENumber } from 'riek';
+import { RIEInput } from 'riek';
 import _ from 'lodash';
 
 import type { Code as CodeType } from '../../types/Code';
@@ -47,7 +47,9 @@ export class Codes extends Component<CodesProps> {
       "SNOMED-CT": TypeTemplates.Code.Snomed,
       "LOINC": TypeTemplates.Code.Loinc,
       "RxNorm": TypeTemplates.Code.RxNorm,
-      "NUBC": TypeTemplates.Code.Nubc
+      "NUBC": TypeTemplates.Code.Nubc,
+      "DICOM-DCM": TypeTemplates.Code.DicomDCM,
+      "DICOM-SOP": TypeTemplates.Code.DicomSOP
     };
     return (
       <div>

--- a/src/components/editor/Goal.js
+++ b/src/components/editor/Goal.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { RIESelect, RIEInput, RIENumber } from 'riek';
 import _ from 'lodash';
 
-import type { Goal as GoalType } from '../../types/Goal';
+import type { Goal as GoalType } from '../../types/Attributes';
 import { Codes } from './Code';
 import { StringsEditor } from './String';
 import { AttributeTemplates } from '../../templates/Templates';

--- a/src/components/editor/ImagingStudyAttributes.js
+++ b/src/components/editor/ImagingStudyAttributes.js
@@ -1,0 +1,124 @@
+// @flow
+
+import React, { Component } from 'react';
+import { RIEInput } from 'riek';
+import _ from 'lodash';
+
+import type { Instance as InstanceType, Series as SeriesType } from '../../types/Attributes';
+
+import { Code } from './Code';
+import { AttributeTemplates } from '../../templates/Templates';
+
+type InstanceProps = {
+  title: string,
+  sop_class: CodeType,
+  onChange: any
+}
+
+export class Instance extends Component<InstanceProps> {
+
+  render() {
+    let title = this.props.title;
+    let sop_class = this.props.sop_class;
+    return (
+      <div>
+        Title: <RIEInput className='editable-text' value={title} propName="title" change={this.props.onChange('title')} />
+        <br />
+        <br />
+        <b>SOP Class:</b>
+        <br />
+        <Code code={sop_class} system={"DICOM-SOP"} onChange={this.props.onChange('sop_class')} />
+      </div>
+    );
+  }
+
+}
+
+type InstanceListProps = {
+  instances: InstanceType[],
+  onChange: any
+}
+
+export class InstanceList extends Component<InstanceListProps> {
+
+  render() {
+    if (!this.props.instances) {
+      return null;
+    }
+    return (
+      <div>
+        {this.props.instances.map((instance, i) => {
+          return (
+            <div className='section' key={i}>
+              <a className='editable-text delete-button' onClick={() => this.props.onChange(`[${i}]`)({val: {id: null}})}>remove</a>
+              <Instance onChange={this.props.onChange(i)} title={instance.title} sop_class={instance.sop_class}/>
+            </div>
+          )
+        })}
+        <a className='editable-text' onClick={() => this.props.onChange(`[${this.props.instances.length}]`)({val: {id: _.cloneDeep(AttributeTemplates.ImagingStudy.Instance)}})}>+</a>
+      </div>
+    );
+  }
+
+}
+
+type SeriesProps = {
+  body_site: CodeType,
+  modality: CodeType,
+  instances: InstanceType[],
+  onChange: any
+}
+
+export class Series extends Component<SeriesProps> {
+
+  render() {
+    let body_site = this.props.body_site;
+    let modality = this.props.modality;
+    let instances = this.props.instances;
+    return (
+      <div className='section'>
+        <b>Body Site:</b>
+        <br />
+        <Code code={body_site} system={"SNOMED-CT"} onChange={this.props.onChange('body_site')} />
+        <br/>
+        <b>Modality:</b>
+        <br />
+        <Code code={modality} system={"DICOM-DCM"} onChange={this.props.onChange('modality')} />
+        <br />
+        <b>Instances:</b>
+        <InstanceList instances={instances} onChange={this.props.onChange('instances')} />
+      </div>
+    )
+  }
+
+}
+
+
+type SeriesListProps = {
+  series: SeriesType[],
+  onChange: any
+}
+
+export class SeriesList extends Component<SeriesListProps> {
+
+  render() {
+    if (!this.props.series) {
+      return null;
+    }
+    return (
+      <div>
+        {this.props.series.map((series, i) => {
+          return (
+            <div className='section' key={i}>
+                <a className='editable-text delete-button' onClick={() => this.props.onChange(`[${i}]`)({val: {id: null}})}>remove</a>
+                <br />
+                <Series onChange={this.props.onChange(i)} body_site={series.body_site} modality={series.modality} instances={series.instances} />
+            </div>
+          )
+        })}
+        <a className='editable-text' onClick={() => this.props.onChange(`[${this.props.series.length}]`)({val: {id: _.cloneDeep(AttributeTemplates.ImagingStudy.Series)}})}>+</a>
+      </div>
+    );
+  }
+
+}

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -3,10 +3,11 @@ import React, { Component } from 'react';
 import { RIESelect, RIEInput, RIENumber, RIEToggle, RIETextArea } from 'riek';
 import _ from 'lodash';
 
-import type { State, InitialState, TerminalState, SimpleState, GuardState, DelayState, SetAttributeState, CounterState, CallSubmoduleState, EncounterState, EncounterEndState, ConditionOnsetState, ConditionEndState, AllergyOnsetState, AllergyEndState, MedicationOrderState, MedicationEndState, CarePlanStartState, CarePlanEndState, ProcedureState, VitalSignState, ObservationState, MultiObservationState, DiagnosticReportState, SymptomState, DeathState } from '../../types/State';
+import type { State, InitialState, TerminalState, SimpleState, GuardState, DelayState, SetAttributeState, CounterState, CallSubmoduleState, EncounterState, EncounterEndState, ConditionOnsetState, ConditionEndState, AllergyOnsetState, AllergyEndState, MedicationOrderState, MedicationEndState, CarePlanStartState, CarePlanEndState, ProcedureState, VitalSignState, ObservationState, MultiObservationState, DiagnosticReportState, ImagingStudyState, SymptomState, DeathState } from '../../types/State';
 
 import { Code, Codes } from './Code';
 import { Goals } from './Goal';
+import { SeriesList } from './ImagingStudyAttributes';
 import ConditionalEditor from './Conditional';
 import Transition from './Transition';
 import { AttributeTemplates, TypeTemplates, StateTemplates } from '../../templates/Templates';
@@ -89,6 +90,8 @@ class StateEditor extends Component<Props> {
         return <MultiObservation {...props} />
       case "DiagnosticReport":
         return <DiagnosticReport {...props} />
+      case "ImagingStudy":
+        return <ImagingStudy {...props} />
       case "Symptom":
         return <Symptom {...props} />
       case "Death":
@@ -1331,6 +1334,29 @@ class DiagnosticReport extends Component<Props> {
           Codes
           <br />
           <Codes codes={state.codes} system={"LOINC"} onChange={this.props.onChange('codes')} />
+        </div>
+      </div>
+    );
+  }
+
+}
+
+class ImagingStudy extends Component<Props> {
+
+  render() {
+    let state = ((this.props.state: any): ImagingStudyState);
+    return (
+      <div>
+        <div className='section'>
+          <b>Procedure Code:</b>
+          <Code code={state.procedure_code} system={"SNOMED-CT"} onChange={this.props.onChange('procedure_code')} />
+          <br />
+        </div>
+        <div className='section'>
+          <b>Series:</b>
+          <br />
+          <SeriesList series={state.series} onChange={this.props.onChange('series')} />
+          <br />
         </div>
       </div>
     );

--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -19,6 +19,16 @@ export const TypeTemplates = {
       system: "NUBC",
       code: "1234",
       display: "NUBC Code"
+    },
+    DicomDCM: {
+      system: "DICOM-DCM",
+      code: "XX",
+      display: "DICOM Modality Code"
+    },
+    DicomSOP: {
+      system: "DICOM-SOP",
+      code: "1.2.3.4.5.6.7.8",
+      display: "DICOM Subject-Object Pair Code"
     }
   },
 
@@ -252,8 +262,22 @@ export const AttributeTemplates = {
   NamedDistribution: {
     attribute: "attribute",
     default: 1.0
-  }
+  },
 
+  ImagingStudy: {
+    Instance: {
+      title: "Title of this image",
+      sop_class: {...TypeTemplates.Code.DicomSOP}
+    },
+    Series: {
+      body_site: {...TypeTemplates.Code.Snomed},
+      modality: {...TypeTemplates.Code.DicomDCM},
+      instances: [{
+        title: "Title of this image",
+        sop_class: {...TypeTemplates.Code.DicomSOP}
+      }]
+    }
+  }
 }
 
 
@@ -384,6 +408,12 @@ export const StateTemplates = {
     type: "DiagnosticReport",
     number_of_observations: 0,
     codes: [{...TypeTemplates.Code.Loinc}]
+  },
+
+  ImagingStudy: {
+    type: "ImagingStudy",
+    procedure_code: {...TypeTemplates.Code.Snomed},
+    series: [{...AttributeTemplates.ImagingStudy.Series}]
   },
 
   Symptom: {

--- a/src/types/Attributes.js
+++ b/src/types/Attributes.js
@@ -10,3 +10,14 @@ export type Goal = {
   text?: string,
   addresses: string[]
 }
+
+export type Instance = {
+  title: string,
+  sop_class: Code
+}
+
+export type Series = {
+  body_site: Code,
+  modality: Code,
+  instances: Instance[]
+}

--- a/src/types/Code.js
+++ b/src/types/Code.js
@@ -1,6 +1,6 @@
 // @flow
 export type Code = {
-  system: "SNOMED-CT" | "RxNorm" | "LOINC",
+  system: "SNOMED-CT" | "RxNorm" | "LOINC" | "NUBC" | "DICOM-DCM" | "DICOM-SOP",
   code: string,
   display: string
 }

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -2,7 +2,7 @@
 import type { Transition } from './Transition';
 import type { Conditional } from './Conditional';
 import type { Code } from './Code';
-import type { Goal } from './Goal';
+import type { Goal, Series } from './Attributes';
 import type { UnitOfTime } from './Units';
 
 export type InitialState = {
@@ -257,6 +257,15 @@ export type DiagnosticReportState = {
   type: 'DiagnosticReport',
   number_of_observations: number,
   codes: Code[],
+  transition?: Transition
+}
+
+export type ImagingStudyState = {
+  name: string,
+  remarks: string[],
+  type: 'ImagingStudy',
+  procedure_code: Code,
+  series: Series[],
   transition?: Transition
 }
 

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -272,6 +272,18 @@ const stateDescription = (state) =>{
         details = `Record value from Attribute '${state["attribute"]}' ${unit}\\l`
       }
       break;
+      
+    case 'ImagingStudy':
+      let series = state['series'];
+      if (series.length > 0) {
+        let primarySeries = series[0];
+        let primaryModality = primarySeries['modality'];
+        let primaryBodySite = primarySeries['body_site'];
+
+        details = `DICOM-DCM[${primaryModality['code']}]: ${primaryModality['display']}\\l`
+        details += `SNOMED-CT[${primaryBodySite['code']}]: Body Site: ${primaryBodySite['display']}\\l`
+      }
+      break;
 
     case 'Counter':
       details = `${state['action']} value of attribute '${state["attribute"]}' by 1`


### PR DESCRIPTION
@jawalonoski @dehall 

This PR adds the ImagingStudy state introduced in https://github.com/synthetichealth/synthea/pull/287 to the module builder.

## Example of editing an ImagingStudy

![edit-imaging-study](https://user-images.githubusercontent.com/5651138/38772448-cc62fc46-3feb-11e8-9d61-8952164fd1c2.png)

## Other noteworthy changes

* I added the `Instance`, `InstanceList`, `Series`, and `SeriesList` components that are used to render the complex nested hierarchy of an ImagingStudy state when editing.

* Although not a precedent with the existing states, I decided to bold the titles of the various ImagingStudy attributes and add additional whitespace using `<br />`s to help them stand out against the data they represent. For example:

![bold-titles](https://user-images.githubusercontent.com/5651138/38772503-3492bba2-3fed-11e8-9492-ab214a26c498.png)

feels clearer and easier to read than:

![non-bold-titles](https://user-images.githubusercontent.com/5651138/38772526-a4150c82-3fed-11e8-9bc5-147d02de27c1.png)

* I renamed the `types/Goals.js` file to `types/Attributes.js`. This file now more generically holds the complex attribute types of various states.

## Outstanding issue with the `RIEInput` component:

Some aspect of the way our `RIEInput` component trims strings after editing is causing it to truncate DICOM SOP codes after the first period `.`, as if they were numbers, even though `code` is explicitly typed as a `string`. The SOP codes are our first instance of period-delimited codes in this project. For example, after editing:

`1.2.840.10008.1.2.3.4.5` => `1.2`

This happens in _any_ RIEInput form for strings in our UI, but only when the code starts with a numeric value. For example, this _does not_ get truncated:

`a1.2.840.10008.1.2.3.4.5` => `a1.2.840.10008.1.2.3.4.5`

This leads me to believe that the RIEInput is inferring that the value is a number if it starts with a numeric character, and tries to be helpful by truncating it appropriately.

In general, I'm somewhat concerned about the longevity of the [riek](https://github.com/kaivi/riek) project that these components come from. It appears to be poorly maintained by @kaivi, and @FizzyGalacticus [shares the same concern](https://github.com/kaivi/riek/issues/74).

@FizzyGalacticus seems to have taken ownership of outstanding PRs and issues in his own fork of the riek project [here](https://github.com/attently/riek). This is also available as an NPM package, so perhaps it's worth switching to a version that is more likely to be maintained in the future?