### PR TITLE
Changed "Enter Value" to "Add Remarks"

### DIFF
--- a/src/components/editor/State.css
+++ b/src/components/editor/State.css
@@ -60,11 +60,11 @@ span.editable-text:empty {
 }
 
 span.editable-text:empty:after {
-  content: 'Enter value';
+  content: 'Add Remarks';
 }
 
-span.editable-text > :empty:after {
-  content: 'Enter value';
+span.editable-text > :first-child:empty:after {
+  content: 'Add Remarks';
 }
 
 .section {


### PR DESCRIPTION
Fixes #219 with a CSS change, making the content when the text area is empty "Add Remarks" instead of "Enter Value", and restricting the behavior to the first child of the parent span so that empty lines don't have "Add Remarks" on them.

Previously empty newlines would be considered as an empty span and have their content set to "Enter Value".  The new class allows for empty lines, but still will put a stray "Add Remarks" if the first line if it is left empty. 