### PR TITLE
Fix firefox menu padding issue.

### DIFF
--- a/src/components/menu/Download.css
+++ b/src/components/menu/Download.css
@@ -1,4 +1,5 @@
 .Download {
+  height: 0;
   overflow-y: scroll;
 }
 


### PR DESCRIPTION
Noticed there is an issue with the top padding in Firefox that doesn't show up in Chrome & Safari:

![screen shot 2018-08-08 at 10 07 04 am](https://user-images.githubusercontent.com/412901/43842303-0bdb091a-9af3-11e8-899b-cd53dd375ec8.png)

This fixes that issue.