### PR TITLE
Add support for the create_administration boolean on MedicationOrder State objects

### DIFF
--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -741,7 +741,7 @@ class MedicationOrder extends Component<Props> {
     let state = ((this.props.state: any): MedicationOrder);
     return (
       <div>
-        <input type="checkbox" checked={state.create_administration} onChange={() => this.props.onChange('create_administration')({val: {id: !state.create_administration}})} /> Create a companion MedicationAdministration
+        <input type="checkbox" checked={state.administration} onChange={() => this.props.onChange('administration')({ val: { id: !state.administration } })} /> Administration of the medication.
       </div>
     );
   }

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -732,6 +732,16 @@ class MedicationOrder extends Component<Props> {
           <br />
         </div>
         {this.renderPrescription()}
+        {this.renderCreateAdministration()}
+      </div>
+    );
+  }
+
+  renderCreateAdministration() {
+    let state = ((this.props.state: any): MedicationOrder);
+    return (
+      <div>
+        <input type="checkbox" checked={state.create_administration} onChange={() => this.props.onChange('create_administration')({val: {id: !state.create_administration}})} /> Create a companion MedicationAdministration
       </div>
     );
   }

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -140,7 +140,7 @@ export type MedicationOrderState = {
   remarks: string[],
   type: 'MedicationOrder',
   assign_to_attribute?: string,
-  create_administration?: boolean,
+  administration?: boolean,
   reason?: string,
   codes: Code[],
   prescription?: {

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -140,6 +140,7 @@ export type MedicationOrderState = {
   remarks: string[],
   type: 'MedicationOrder',
   assign_to_attribute?: string,
+  create_administration?: boolean,
   reason?: string,
   codes: Code[],
   prescription?: {

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -420,6 +420,9 @@ const stateDescription = (state) =>{
   if(state.assign_to_attribute){
     details = details + `Assign to Attribute: '${state['assign_to_attribute']}'\\l`
   }
+  if(state.create_administration){
+    details = details + `Companion MedicationAdministration will be created\\l`
+  }
   if(state.referenced_by_attribute){
     details = details + `Referenced By Attribute: '${state['referenced_by_attribute']}'\\l`
   }

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -420,8 +420,8 @@ const stateDescription = (state) =>{
   if(state.assign_to_attribute){
     details = details + `Assign to Attribute: '${state['assign_to_attribute']}'\\l`
   }
-  if(state.create_administration){
-    details = details + `Companion MedicationAdministration will be created\\l`
+  if(state.administration){
+    details = details + `Medication is administered\\l`
   }
   if(state.referenced_by_attribute){
     details = details + `Referenced By Attribute: '${state['referenced_by_attribute']}'\\l`


### PR DESCRIPTION
This PR adds support for the addition of a `create_administration` boolean attribute to `MedicationOrder` State objects for Synthea's Generic Module Framework. 

Added features:

- Renders a checkbox on `MedicationOrder` states to `"Create a companion MedicationAdministration"` (please feel free to suggest a more appropriate wording) that corresponds to the `create_administration` attribute
- Adds a note to the state in the Graphviz representation if the `create_administration` attribute is true
- Properly imports & exports GMF JSON with the `create_administration` attribute set.

Screenshots:
The UI element (at the bottom of the screenshot) for the `create_administration` attribute
![Screen Shot 2019-04-29 at 11 09 59 AM](https://user-images.githubusercontent.com/49001/56906246-d2ad5600-6a6f-11e9-8fa2-9227a5909fba.png)

The note added to the node in Graphviz when the attribute is true
![Screen Shot 2019-04-29 at 11 10 09 AM](https://user-images.githubusercontent.com/49001/56906245-d2ad5600-6a6f-11e9-8ab0-4fba7ff19cd3.png)

The resulting GMF JSON
![Screen Shot 2019-04-29 at 11 10 28 AM](https://user-images.githubusercontent.com/49001/56906244-d2ad5600-6a6f-11e9-8fde-18797655ebf3.png)
