### PR TITLE
Add decimal formatting to fix floating point to string issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3357,6 +3357,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js-light": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.0.tgz",
+      "integrity": "sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg=="
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "4.0.0-beta.2",
     "chai": "^4.1.2",
     "chai-jquery": "^2.0.0",
+    "decimal.js-light": "^2.5.0",
     "file-saver": "^1.3.3",
     "history": "^4.7.2",
     "jquery": "^3.2.1",

--- a/src/components/editor/DistributedTransition.js
+++ b/src/components/editor/DistributedTransition.js
@@ -2,13 +2,12 @@
 import React, { Component } from 'react';
 import { RIESelect, RIEInput, RIENumber } from 'riek';
 import _ from 'lodash';
-
+import { Decimal } from 'decimal.js-light';
 
 import type { DistributedTransition as DistributedTransitionType } from '../../types/Transition';
 import { getTemplate } from '../../templates/Templates';
 import type { State } from '../../types/State';
 import './Transition.css';
-
 
 type Props = {
   options: State[],
@@ -52,7 +51,8 @@ class DistributedTransition extends Component<Props> {
     let sum = this.props.transition.transition.reduce( (acc, val) => acc + (typeof val.distribution === 'object' ? val.distribution.default : val.distribution),0);
     let remainder = 0;
     if(typeof distribution === 'object') {
-      remainder = 1 - (sum - distribution.default);
+      let dp = Math.max(new Decimal(sum).decimalPlaces(),Decimal(distribution.default).decimalPlaces());
+      remainder = 1 - new Decimal(sum - distribution.default).toFixed(dp).valueOf();
       let remainderOption = null
       if (sum != 1) {
         remainderOption = <a className='editable-text' onClick={() => this.props.onChange(`[${index}].distribution.default`)({val: remainder})}>(Change to Remainder)</a>
@@ -68,7 +68,8 @@ class DistributedTransition extends Component<Props> {
         </label>
       );
     } else {
-      remainder = 1 - (sum - distribution);
+      let dp = Math.max(new Decimal(sum).decimalPlaces(),Decimal(distribution).decimalPlaces());
+      remainder = 1 - new Decimal(sum - distribution).toFixed(dp).valueOf();
       let remainderOption = null
       if (sum != 1) {
         remainderOption = <a className='editable-text' onClick={() => this.props.onChange(`[${index}].distribution`)({val: remainder})}>(Change to Remainder)</a>
@@ -97,7 +98,9 @@ class DistributedTransition extends Component<Props> {
   }
 
   formatAsPercentage(num: number) {
-    return (num * 100) + "%";
+    const y = new Decimal(num);
+    const places = Math.max(y.decimalPlaces() - 2,1);
+    return (y*100).toFixed(places).toString() + "%";
   }
 
   checkInRange(num: number) {

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -12,7 +12,7 @@ import ConditionalEditor from './Conditional';
 import Transition from './Transition';
 import { getTemplate } from '../../templates/Templates';
 import { BasicTutorial, EditTutorial } from '../../templates/Tutorial';
-
+import { Decimal } from 'decimal.js-light';
 
 import './State.css';
 
@@ -1595,7 +1595,9 @@ class Symptom extends Component<Props> {
   }
 
   formatAsPercentage(num: number) {
-    return (num * 100) + "%";
+    const y = new Decimal(num);
+    const places = Math.max(y.decimalPlaces() - 2,1);
+    return (y*100).toFixed(places).toString() + "%";
   }
 
   renderCause() {

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -1,6 +1,7 @@
 // @flow
 import type { Module } from './types/Module';
 import type { State } from './types/State';
+import { Decimal } from 'decimal.js-light';
 
 import { cleanString } from '../utils/stringUtils';
 
@@ -124,12 +125,13 @@ const transitionsAsDOT = (module: Module, selectedState: State, selectedStateTra
         if(typeof t.distribution === 'object'){
           distLabel = `p(${t.distribution.attribute})`
           if(t.distribution.default){
-            let pct = t.distribution.default * 100
-            distLabel += `, default ${pct}%`
+            // let pct = t.distribution.default * 100
+            let pct = formatAsPercentage(t.distribution.default)
+            distLabel += `, default ${pct}`
           }
         } else {
-          let pct = t.distribution * 100
-          distLabel = `${pct}%`
+          let pct = formatAsPercentage(t.distribution)
+          distLabel = `${pct}`
         }
         if(module.states[t.transition]){
           if(selectedState && t.transition === selectedState.name && selectedState.name !== name){
@@ -188,7 +190,8 @@ const transitionsAsDOT = (module: Module, selectedState: State, selectedStateTra
         } else {
           t.distributions.forEach( dist => {
             if(module.states[dist.transition]){
-              let pct = dist.distribution * 100
+              let pct = formatAsPercentage(dist.distribution)
+
               let nodes = `  "${escapedName}" -> "${dist.transition}"`
               if(selectedState && dist.transition === selectedState.name){
                 nodeHighlighted[nodes] = 'standard'
@@ -199,7 +202,7 @@ const transitionsAsDOT = (module: Module, selectedState: State, selectedStateTra
               if(transitions[nodes] === undefined){
                 transitions[nodes] = [];
               }
-              transitions[nodes].push(`${cnd}: ${pct}%`)
+              transitions[nodes].push(`${cnd}: ${pct}`)
             } else {
               console.log(`NO SUCH NODE TO TRANSITION TO: ${dist.transition} FROM ${name}`);
             }
@@ -281,8 +284,8 @@ const stateDescription = (state) =>{
         details = `${s}: ${e['quantity']}`
       }
       if (p && p < 1.0 && p > 0) {
-        let pct = p*100;
-        details += ` (${pct}%)`
+        let pct = formatAsPercentage(p)
+        details += ` (${pct})`
       }
       break;
     case 'Observation':
@@ -611,6 +614,12 @@ const escapeLabel = (label) => {
   return cleanString(label, mapObj);
 
 }
+
+const formatAsPercentage = (num) => {
+    const y = new Decimal(num);
+    const places = Math.max(y.decimalPlaces() - 2,1);
+    return (y*100).toFixed(places).toString() + "%";
+  }
 
 export const svgDefs = `<defs>
 


### PR DESCRIPTION
Fixes JS fp to string conversion issues (e.g. 94.399999999999999%)
Checks for significant digits in user entered values rather than using fixed number of decimal places. 
Shows at least 1 decimal place for percentages (e.g. 3% becomes 3.0%. 0.5% means the remainder is shown as 99.5%. 0.05% gives a remainder of 99.95%, etc.)
