### PR TITLE
Fix error when deploying to a non-root path /module-builder.

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -17,7 +17,7 @@ if (process.env.NODE_ENV === 'development') {
   }
 }
 
-export const history = createBrowserHistory()
+export const history = createBrowserHistory({basename: '/module-builder'})
 
 const createAppStore = (history) => {
   middleware.push(routerMiddleware(history))


### PR DESCRIPTION
Updates to packages caused an issue with deployment, which is under the /module-builder path on the server.  It appears that the new Router (which decides what views to show based on the path), now pays attention to the path that the app lives under.  This caused a strange situation where the app worked during development (because it was run at the root of localhost) but show a blank screen when deployed to production (because it runs under /module-builder).

There may be a cleaner way of accomplishing this, but it would take some digging into the library.  This does appear to work for both development (`npm start`) and when deploying under a sub directory (you can simulate production locally by doing something like this: `npm build` then moving the generated files that got put in `build` to a folder named `module-builder` and then starting a web server in the folder above that using something like `python -m SimpleHTTPServer` and then navigating to `localhost:8000/module-builder`).