### PR TITLE
Add amount field to Counter state

### DIFF
--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -305,6 +305,8 @@ class Counter extends Component<Props> {
         Attribute: <RIEInput className='editable-text' value={state.attribute} propName={'attribute'} change={this.props.onChange('attribute')} />
         <br/>
         Action: <RIESelect className='editable-text' value={{id: state.action, text: state.action}} propName="action" change={this.props.onChange('action')} options={options} />
+        <br/>
+        Amount: <RIENumber className='editable-text' value={state.amount || 1} propName='amount' change={this.props.onChange('amount')} />
       </div>
     );
   }

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -340,7 +340,7 @@ const stateDescription = (state) =>{
       break;
 
     case 'Counter':
-      details = `${state['action']} value of attribute '${state["attribute"]}' by 1`
+      details = `${state['action']} value of attribute '${state["attribute"]}' by ${state['amount'] || 1}`
       break;
     case 'VitalSign':
       let vs = state['vital_sign']


### PR DESCRIPTION
Adds an `amount` field to the Counter state, so that counters can count 2 by 2, or 17 by 17, or whatever number you like. Defaults to 1 if the field is not present, so all current usage of the Counter state will work without explicitly adding the field.

Main Synthea PR: https://github.com/synthetichealth/synthea/pull/665