### PR TITLE
Automatically deploy to GitHub pages following successful build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,13 @@ cache:
   - node_modules
 script:
   - yarn test
+  - yarn build
+
+deploy:
+  provider: pages
+  local_dir: build
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  keep_history: true
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ cache:
   - node_modules
 script:
   - yarn test
-  - yarn build
+  # TODO: have to set CI=false on the build because it treats warnings as errors otherwise
+  - CI=false yarn build
 
 deploy:
   provider: pages


### PR DESCRIPTION
Adds a build and deploy step to travis such that it will redeploy to github pages (ie, https://synthetichealth.github.io/module-builder) following a push to master and successful build. 

Note that this requires a github token to be set in the Travis config - I have already set that up