### PR TITLE
Fix lookup table transitions

### DIFF
--- a/scripts/build-modules.js
+++ b/scripts/build-modules.js
@@ -82,17 +82,17 @@ for(var i = 0; i< files.length; i++){
     Object.keys(json.states).map(k => json.states[k]).forEach( s => {  
 
       // find table transitions and add state data
-      if (s.table_transition !== undefined){ 
+      if (s.lookup_table_transition !== undefined){ 
 
         // save the name and set the table view to be in the edit mode
-        s.table_transition.lookup_table_name_ModuleBuilder = s.table_transition.transitions[0].lookup_table_name;
+        s.lookup_table_transition.lookup_table_name_ModuleBuilder = s.lookup_table_transition.transitions[0].lookup_table_name;
         s.viewTable = false;
 
         // find the file using the table name
         var tableFiles = walkSync(tableDirectory, ".csv");
         var csvLocation = '';
         tableFiles.forEach( file => {
-          if (file.toUpperCase().includes(s.table_transition.lookup_table_name_ModuleBuilder.toUpperCase()))
+          if (file.toUpperCase().includes(s.lookup_table_transition.lookup_table_name_ModuleBuilder.toUpperCase()))
           {
             csvLocation = file;
           }
@@ -102,14 +102,14 @@ for(var i = 0; i< files.length; i++){
         if (csvLocation === '')
         {      
           console.log('\x1b[1m')
-          console.log('\n\nLookup Table \'' + s.table_transition.lookup_table_name_ModuleBuilder + '\' not found.\n')
+          console.log('\n\nLookup Table \'' + s.lookup_table_transition.lookup_table_name_ModuleBuilder + '\' not found.\n')
           console.log('Please ensure the table exists in the directory ' + tableDirectory)
           console.log('\x1b[0m')
           process.exit()
         }
         
         // read the csv and save it
-        s.table_transition.lookuptable = fs.readFileSync(csvLocation, 'utf8');
+        s.lookup_table_transition.lookuptable = fs.readFileSync(csvLocation, 'utf8');
       }
     });
 

--- a/src/components/editor/Transition.js
+++ b/src/components/editor/Transition.js
@@ -27,7 +27,7 @@ class Transition extends Component<Props> {
         case "Complex":
           return <ComplexTransition {...this.props} onChange={this.props.onChange('complex_transition')} />
         case "Table":
-          return <TableTransition {...this.props} onChange={this.props.onChange('table_transition')} />
+          return <TableTransition {...this.props} onChange={this.props.onChange('lookup_table_transition')} />
         case "None":
           return <div> No transition </div>
         default:

--- a/src/components/menu/Download.js
+++ b/src/components/menu/Download.js
@@ -31,8 +31,8 @@ class Download extends Component {
     Object.keys(module.states).map(k => module.states[k]).forEach( s => {
 
       // find table transitions and download the tables
-      if (s.table_transition !== undefined){
-        this.downloadCsv(s.table_transition.lookup_table_name_ModuleBuilder, s.table_transition.lookuptable);
+      if (s.lookup_table_transition !== undefined){
+        this.downloadCsv(s.lookup_table_transition.lookup_table_name_ModuleBuilder, s.lookup_table_transition.lookuptable);
       }
 
     })
@@ -64,15 +64,16 @@ class Download extends Component {
       }
 
       // find table transitions and delete state data
-      if (s.table_transition !== undefined){
-        let name = s.table_transition.lookup_table_name_ModuleBuilder;
-        s.table_transition.transitions.forEach( t => 
+      if (s.lookup_table_transition !== undefined){
+        let name = s.lookup_table_transition.lookup_table_name_ModuleBuilder;
+        s.lookup_table_transition.transitions.forEach( t => 
           {
             t.lookup_table_name = name;
           })
-        delete s.table_transition.lookup_table_name_ModuleBuilder;
-        delete s.table_transition.lookuptable;
-        delete s.table_transition.viewTable;
+        delete s.lookup_table_transition.lookup_table_name_ModuleBuilder;
+        delete s.lookup_table_transition.lookuptable;
+        delete s.lookup_table_transition.viewTable;
+        s.lookup_table_transition = s.lookup_table_transition.transitions;
       }
 
     })

--- a/src/components/menu/LoadModule.js
+++ b/src/components/menu/LoadModule.js
@@ -27,14 +27,19 @@ class LoadModule extends Component {
       // need to get the tables for any table transition
       for (var key in module.states)
       {
-        if (module.states[key].table_transition != null)
+        if (module.states[key].lookup_table_transition != null)
         { 
           tableMessage += key.toString() + ' & '
+
+          // this is an awful hack to get around a data model mismatch
+          const lttWrapper = { type: 'Table', transitions: module.states[key].lookup_table_transition };
+          module.states[key].lookup_table_transition = lttWrapper;
+
           
           // put default data in for state of the table transition
-          module.states[key].table_transition.lookup_table_name_ModuleBuilder = module.states[key].table_transition.transitions[0].lookup_table_name;
-          module.states[key].table_transition.viewTable = false;    
-          module.states[key].table_transition.lookuptable = '';
+          module.states[key].lookup_table_transition.lookup_table_name_ModuleBuilder = module.states[key].lookup_table_transition.transitions[0].lookup_table_name;
+          module.states[key].lookup_table_transition.viewTable = false;    
+          module.states[key].lookup_table_transition.lookuptable = '';
         }
       }
 

--- a/src/reducers/analysis.js
+++ b/src/reducers/analysis.js
@@ -111,12 +111,12 @@ const tableTransitionWarnings = (module) => {
     let state = module.states[stateName];
 
     // find table transitions and check table data
-    if (state.table_transition !== undefined){
+    if (state.lookup_table_transition !== undefined){
       let message = '';
-      if(state.table_transition.lookup_table_name_ModuleBuilder === ""){
+      if(state.lookup_table_transition.lookup_table_name_ModuleBuilder === ""){
         message = 'Invalid filename ';
       }
-      if (state.table_transition.lookuptable === "Enter table" || tableHasError(state.table_transition.lookuptable) ) { 
+      if (state.lookup_table_transition.lookuptable === "Enter table" || tableHasError(state.lookup_table_transition.lookuptable) ) { 
         if (message === ''){ 
           message = 'Invalid data ';
         } else {
@@ -124,16 +124,16 @@ const tableTransitionWarnings = (module) => {
         }
       }
       // check the last X columns vs X transitions
-      if (!tableHasError(state.table_transition.lookuptable)){
+      if (!tableHasError(state.lookup_table_transition.lookuptable)){
         let tableColumns = [];
-        let data = parseLookupTable(state.table_transition.lookuptable);
+        let data = parseLookupTable(state.lookup_table_transition.lookuptable);
         if (data.length > 0){ 
           tableColumns = Object.keys(data[0]);
         }
 
-        for (let i = 0; i < state.table_transition.transitions.length; i++)
+        for (let i = 0; i < state.lookup_table_transition.transitions.length; i++)
         {
-          let transition = state.table_transition.transitions[state.table_transition.transitions.length - i - 1].transition;
+          let transition = state.lookup_table_transition.transitions[state.lookup_table_transition.transitions.length - i - 1].transition;
           let column = tableColumns[tableColumns.length-i -1];
           if (transition != column)
           {
@@ -251,8 +251,8 @@ const orphanStateWarnings = (module) => {
           }
         }
       });
-    } else if(nextState.table_transition){
-      nextState.table_transition.transitions.forEach(transition => {
+    } else if(nextState.lookup_table_transition){
+      nextState.lookup_table_transition.transitions.forEach(transition => {
         if(!module.states[transition.transition]){
           warnings.push({stateName: nextStateKey, message: 'Transition to state that does not exist: ' + transition.transition});
         } else {

--- a/src/reducers/editor.js
+++ b/src/reducers/editor.js
@@ -83,10 +83,10 @@ export default (state = initialState, action) => {
           alteredState.distributed_transition[action.data.selectedStateTransition] = {...alteredState.distributed_transition[action.data.selectedStateTransition], transition: action.data.stateKey}
           newState.modules[action.data.currentModuleKey].states[action.data.stateKey].direct_transition = oldTransitionPoint;
           newState.modules[action.data.currentModuleKey].states[action.data.selectedState] = alteredState;
-        } else if(alteredState.table_transition){
-          let oldTransitionPoint = alteredState.table_transition[action.data.selectedStateTransition].transition;
-          alteredState.table_transition = [...alteredState.table_transition]
-          alteredState.table_transition[action.data.selectedStateTransition] = {...alteredState.table_transition[action.data.selectedStateTransition], transition: action.data.stateKey}
+        } else if(alteredState.lookup_table_transition){
+          let oldTransitionPoint = alteredState.lookup_table_transition[action.data.selectedStateTransition].transition;
+          alteredState.lookup_table_transition = [...alteredState.lookup_table_transition]
+          alteredState.lookup_table_transition[action.data.selectedStateTransition] = {...alteredState.lookup_table_transition[action.data.selectedStateTransition], transition: action.data.stateKey}
           newState.modules[action.data.currentModuleKey].states[action.data.stateKey].direct_transition = oldTransitionPoint;
           newState.modules[action.data.currentModuleKey].states[action.data.selectedState] = alteredState;
         } else if(alteredState.conditional_transition){
@@ -150,7 +150,7 @@ export default (state = initialState, action) => {
         delete newState.modules[action.data.currentModuleKey].states[action.data.stateKey]['conditional_transition']
         delete newState.modules[action.data.currentModuleKey].states[action.data.stateKey]['distributed_transition']
         delete newState.modules[action.data.currentModuleKey].states[action.data.stateKey]['complex_transition']
-        delete newState.modules[action.data.currentModuleKey].states[action.data.stateKey]['table_transition']
+        delete newState.modules[action.data.currentModuleKey].states[action.data.stateKey]['lookup_table_transition']
 
 
         if(alteredState.direct_transition){
@@ -158,9 +158,9 @@ export default (state = initialState, action) => {
         } else if(alteredState.distributed_transition){
           newState.modules[action.data.currentModuleKey].states[action.data.stateKey].distributed_transition = _.cloneDeep(alteredState.distributed_transition);
           delete alteredState['distributed_transition']
-        } else if(alteredState.table_transition){
-          newState.modules[action.data.currentModuleKey].states[action.data.stateKey].table_transition = _.cloneDeep(alteredState.table_transition);
-          delete alteredState['table_transition']
+        } else if(alteredState.lookup_table_transition){
+          newState.modules[action.data.currentModuleKey].states[action.data.stateKey].lookup_table_transition = _.cloneDeep(alteredState.lookup_table_transition);
+          delete alteredState['lookup_table_transition']
         } else if(alteredState.conditional_transition){
           newState.modules[action.data.currentModuleKey].states[action.data.stateKey].conditional_transition = _.cloneDeep(alteredState.conditional_transition);
           delete alteredState['conditional_transition']
@@ -282,7 +282,7 @@ export default (state = initialState, action) => {
       else{
         _.unset(newState.modules, path);
         let parent = [...action.data.path].splice(0, action.data.path.length -1).join(".");
-        if (action.data.path[2] == 'table_transition'){
+        if (action.data.path[2] == 'lookup_table_transition'){
          parent  += '.transitions'
         }
         let newVal = _.get(newState.modules, parent);
@@ -320,7 +320,7 @@ export default (state = initialState, action) => {
         Distributed: 'distributed_transition',
         Direct: 'direct_transition',
         Complex: 'complex_transition',
-        Table: 'table_transition',
+        Table: 'lookup_table_transition',
       };
 
       let transitionName = transitionMapping[action.data.transitionType];
@@ -348,7 +348,7 @@ export default (state = initialState, action) => {
         case 'complex_transition':
           transitionTo = _.get(action, 'data.nodeName.transition.transition[0].distributions[0].to', null);
           break;
-        case 'table_transition':
+        case 'lookup_table_transition':
           transitionTo = _.get(action, 'data.nodeName.transition.transitions.transition[0].to', null);
           break;
       }
@@ -366,7 +366,7 @@ export default (state = initialState, action) => {
           case 'complex_transition':
             newState.modules[action.data.currentModuleKey].states[action.data.nodeName.name][transitionName][0].distributions[0].transition = transitionTo;
             break;
-          case 'table_transition':
+          case 'lookup_table_transition':
             newState.modules[action.data.currentModuleKey].states[action.data.nodeName.name][transitionName].transitions[0].transition = transitionTo;
             break;
         }
@@ -432,7 +432,7 @@ export default (state = initialState, action) => {
       // TODO figure out how to remove unused fields
       newState.modules[action.data.targetModuleKey].states[action.data.targetNode.name] =
         { ...getTemplate(`State.${newType}`),
-          ..._.pick(newState.modules[action.data.targetModuleKey].states[action.data.targetNode.name], ['direct_transition', 'conditional_transition', 'distributed_transition', 'complex_transition', 'table_transition', 'remarks']),
+          ..._.pick(newState.modules[action.data.targetModuleKey].states[action.data.targetNode.name], ['direct_transition', 'conditional_transition', 'distributed_transition', 'complex_transition', 'lookup_table_transition', 'remarks']),
           type: getTemplate(`State.${newType}`).type
         };
 
@@ -525,8 +525,8 @@ const fixStateReferences = (module, stateName, newName) => {
           }
         }
       })
-    } else if (state.table_transition){
-      state.table_transition.transitions.forEach( transition => {
+    } else if (state.lookup_table_transition){
+      state.lookup_table_transition.transitions.forEach( transition => {
         if(transition.transition === stateName){
           if(newName === null){
             delete transition.transition
@@ -666,8 +666,8 @@ const renameLoopbackTransition = (state, newStateName, oldStateName) => {
         transition.transition = newStateName
       }
     })
-  } else if (state.table_transition){
-    state.table_transition.forEach( transition => {
+  } else if (state.lookup_table_transition){
+    state.lookup_table_transition.forEach( transition => {
       if(transition.transition === oldStateName){
         transition.transition = newStateName
       }

--- a/src/transforms/Module.js
+++ b/src/transforms/Module.js
@@ -42,8 +42,8 @@ export function extractTransition(state: any): ?Transition {
   if(state.complex_transition) {
     return extractComplexTransition(state.complex_transition);
   }
-  if(state.table_transition) {
-    return extractTableTransition(state.table_transition);
+  if(state.lookup_table_transition) {
+    return extractTableTransition(state.lookup_table_transition);
   }
   return null;
 }

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -145,9 +145,9 @@ const transitionsAsDOT = (module: Module, selectedState: State, selectedStateTra
         }
       })
       return out_transitions
-    } else if(state.table_transition !== undefined){
+    } else if(state.lookup_table_transition !== undefined){
         let out_transitions = ''
-        state.table_transition.transitions.forEach( (t, i) => {
+        state.lookup_table_transition.transitions.forEach( (t, i) => {
         let transitionClassName = className
         let pct = t.default_probability * 100
         let distLabel = `${pct}%`


### PR DESCRIPTION
Fixes a bug with lookup table transitions, as there seems to be a data model inconsistency between the module builder and synthea proper.
1) Did a global search & replace of "table_transition" to "lookup_table_transition" as the latter is the correct field name as used in Synthea.
2) Added some hackish logic to convert the lookup table transition format on load and download. (see additions with no corresponding delete in LoadModule.js and Download.js) This is definitely not the best approach but it's the fastest.

An example to test with - load from GitHub modules, covid19 branch, covid19.json module.