### PR TITLE
Add Device.assign_to_attribute and DeviceEnd state

### DIFF
--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -504,6 +504,10 @@ const StateTemplates = {
     code: {...TypeTemplates.Code.Snomed}
   },
 
+  DeviceEnd: {
+    type: "DeviceEnd"
+  },
+
   SupplyList: {
     type: "SupplyList",
     supplies: [{...AttributeTemplates.Supply}]

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -278,6 +278,16 @@ export type DeviceState = {
   transition?: Transition
 }
 
+export type DeviceEndState = {
+  name: string,
+  remarks: string[],
+  type: 'DeviceEnd',
+  device?: string,
+  referenced_by_attribute?: string,
+  codes?: Code[],
+  transition?: Transition
+}
+
 export type SupplyListState = {
   name: string,
   remarks: string[],

--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -411,6 +411,12 @@ const stateDescription = (state) =>{
       }
       break;
 
+    case 'DeviceEnd':
+      if (state.device) {
+        details = `Added at: ${state.device}\\l`;
+      }
+      break;
+
     case 'SupplyList':
       if(state.supplies && state.supplies.length > 0){
         let supplyQuantity = ['Quantity']


### PR DESCRIPTION
Adds a new DeviceEnd state which accepts either the name of a Device state, a code, or an attribute containing a Device to remove from the patient. This is largely copy & pasted from the ConditionOnset state.
Also adds an `assign_to_attribute` field to Device so devices can be ended by attribute.

Neither of these is supported in the core Synthea engine yet.