### PR TITLE
Add support to load/save modules from localStorage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,18 @@ This will start a local copy running at `http://localhost:3000/`
 
 ## Saving Modules
 
-Modules created and edited through the Module Builder must be downloaded and saved as a JSON file.
-The Module Builder currently does not persist local changes across browser sessions, so do not close or navigate
-away from the page without first saving your work as a local file first.  Click the `Download` button at the
+### Download as JSON
+
+Modules created and edited through the Module Builder can be downloaded and saved as a JSON file. Click the `Download` button at the
 top of the interface, and you can either copy the JSON in the modal text box, or click the `Download` button on the bottom
 of the modal to save as a local file.
 
 Once saved as a JSON file (using the `.json` extension), you can use the module within your own local installation of Synthea.
 See the [Generic Module Framework](https://github.com/synthetichealth/synthea/wiki/Generic-Module-Framework#relevant-files-and-paths) for information on where to place the file.
+
+### Save to Local Storage
+
+Modules can also be saved to local storage in the browser. Click the `Download` button at the top of the interface, and click the `Save to Local Storage` button at the bottom of the modal. To load an existing module from local storage, select it from the `Local Storage` list when opening an existing module.
 
 ## Developer Tasks
 

--- a/src/components/menu/Download.js
+++ b/src/components/menu/Download.js
@@ -1,14 +1,18 @@
 import React, { Component } from 'react';
 import FileSaver from 'file-saver';
 import _ from 'lodash'
+import { saveLocalStorageModule } from '../../utils/localStorageHelpers';
 
 import './Download.css';
 
 class Download extends Component {
+  constructor(props) {
+    super(props);
+    this.onDownload = this.onDownload.bind(this);
 
-  constructor(props){
-    super(props)
-    this.onDownload = this.onDownload.bind(this)
+    this.state = {
+      saveSuccess: false,
+    };
   }
   
   onDownload(){
@@ -88,8 +92,21 @@ class Download extends Component {
     })
 
     return JSON.stringify(module, null, 2)
-
   }
+
+  saveToLocalStorage = () => {
+    saveLocalStorageModule(this.props.module);
+
+    this.setState({
+      saveSuccess: true,
+    });
+
+    setTimeout(() => {
+      this.setState({
+        saveSuccess: false,
+      });
+    }, 2000);
+  };
 
   render() {
 
@@ -114,8 +131,14 @@ class Download extends Component {
               <div className="modal-body Download-body">
               <textarea ref="codeInput" disabled value={this.prepareJSON()} />
               </div>
+              {this.state.saveSuccess && (
+                <div>
+                  Successfully saved {this.props.module.name} to local storage
+                </div>
+              )}
               <div className="modal-footer">
-                <button type="button" className="btn btn-secondary" data-dismiss="modal" onClick={this.onDownload}>Download</button>
+                <button type="button" className="btn btn-primary" data-dismiss="modal" onClick={this.onDownload}>Download</button>
+                <button type="button" className="btn btn-secondary" onClick={this.saveToLocalStorage}>Save to Local Storage</button>
                 <button type="button" className="btn btn-secondary" data-dismiss="modal" onClick={this.props.onHide}>Close</button>
               </div>
             </div>

--- a/src/components/menu/Download.js
+++ b/src/components/menu/Download.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import FileSaver from 'file-saver';
 import _ from 'lodash'
-import { saveLocalStorageModule } from '../../utils/localStorageHelpers';
+import { getLocalStorageModuleByName, saveLocalStorageModule } from '../../utils/localStorageHelpers';
 
 import './Download.css';
 
@@ -95,17 +95,26 @@ class Download extends Component {
   }
 
   saveToLocalStorage = () => {
-    saveLocalStorageModule(this.props.module);
+    let shouldSave = true;
+    const localStorageModule = getLocalStorageModuleByName(this.props.module.name)
 
-    this.setState({
-      saveSuccess: true,
-    });
+    if (localStorageModule) {
+      shouldSave = confirm(`Module named "${localStorageModule.module.name}" (Last saved: ${localStorageModule.timestamp}) already exists in local storage. Overwrite?`);
+    }
 
-    setTimeout(() => {
+    if (shouldSave) {
+      saveLocalStorageModule(this.props.module);
+
       this.setState({
-        saveSuccess: false,
+        saveSuccess: true,
       });
-    }, 2000);
+
+      setTimeout(() => {
+        this.setState({
+          saveSuccess: false,
+        });
+      }, 2000);
+    }
   };
 
   render() {

--- a/src/components/menu/LoadModule.js
+++ b/src/components/menu/LoadModule.js
@@ -2,6 +2,10 @@ import React, { Component } from 'react';
 import './LoadModule.css';
 import {generateDOT} from '../../utils/graphviz';
 import StyledDropzone from './StyledDropZone';
+import {
+  getLocalStorageModules,
+  removeLocalStorageModule,
+} from "../../utils/localStorageHelpers";
 
 class LoadModule extends Component {
 
@@ -187,6 +191,30 @@ class LoadModule extends Component {
         </div>
         )
 
+    case 'local-storage':
+      return (
+        <div className="col-4 nopadding">
+          <ul className="LoadModule-list">
+            {Object.keys(this.state.localStorageModules || {}).map(moduleName => (
+              <li key={moduleName}>
+                <div className="btn-group">
+                  <button className='btn btn-link' onClick={() => {
+                    this.loadModule(JSON.stringify(this.state.localStorageModules[moduleName]))
+                  }}>
+                    {moduleName}
+                  </button>
+                  <button type="button" className="close" aria-label="Close" onClick={() => {
+                    removeLocalStorageModule(moduleName);
+                    this.updateLocalStorageModules();
+                  }}>
+                    <span aria-hidden="true">&times;</span>
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
     default:
       return;
 
@@ -213,7 +241,15 @@ class LoadModule extends Component {
       if (i.props.id !== ID) {
         document.getElementById(i.props.id).style.backgroundColor = "#eee";
       }
-    })
+    });
+  }
+
+  updateLocalStorageModules() {
+    const existingModules = getLocalStorageModules();
+
+    this.setState({
+      localStorageModules: existingModules,
+    });
   }
 
   fetchBranchList() {
@@ -286,8 +322,16 @@ class LoadModule extends Component {
   }
 
   componentDidUpdate(prevProps, prevState) {
-    if (this.state.selectedOption === 'git' && prevState.selectedOption !== 'git') {
-      this.fetchBranchList()
+    if (
+      this.state.selectedOption === "git" &&
+      prevState.selectedOption !== "git"
+    ) {
+      this.fetchBranchList();
+    } else if (
+      this.state.selectedOption === "local-storage" &&
+      prevState.selectedOption !== "local-storage"
+    ) {
+      this.updateLocalStorageModules();
     }
   }
 
@@ -331,6 +375,7 @@ class LoadModule extends Component {
                          {Object.keys(this.props.modules).length > 0 ? <li className={(this.state.selectedOption === 'my') ? 'selected' : ''}><button className='btn btn-link' onClick={this.onOptionClick('my')}>My Modules</button></li> : ''}
                          <li className={(this.state.selectedOption === 'json') ? 'selected' : ''}><button className='btn btn-link' onClick={this.onOptionClick('json')}>Paste JSON</button></li>
                          <li className={(this.state.selectedOption === 'git') ? 'selected' : ''}><button className='btn btn-link' onClick={this.onOptionClick('git')}>GitHub Modules</button></li>
+                         <li className={this.state.selectedOption === 'local-storage' ? 'selected' : '' }><button className='btn btn-link' onClick={this.onOptionClick('local-storage')} >Local Storage</button></li>
                       </ul>
                     </div>
                     <div className='col-9 nopadding'>

--- a/src/components/menu/LoadModule.js
+++ b/src/components/menu/LoadModule.js
@@ -193,31 +193,35 @@ class LoadModule extends Component {
 
     case 'local-storage':
       return (
-        <div className="col-4 nopadding">
-          <ul className="LoadModule-list">
-            {Object.keys(this.state.localStorageModules || {}).map(moduleName => (
+        <ul className="LoadModule-list">
+          {Object.keys(this.state.localStorageModules || {}).map(moduleName => { 
+            const moduleEntry = this.state.localStorageModules[moduleName]
+            return (
               <li key={moduleName}>
-                <div className="btn-group">
-                  <button className='btn btn-link' onClick={() => {
-                    this.loadModule(JSON.stringify(this.state.localStorageModules[moduleName]))
-                  }}>
-                    {moduleName}
-                  </button>
-                  <button type="button" className="close" aria-label="Close" onClick={() => {
-                    removeLocalStorageModule(moduleName);
-                    this.updateLocalStorageModules();
-                  }}>
-                    <span aria-hidden="true">&times;</span>
-                  </button>
+                <div className="d-flex">
+                  <div className="flex-grow-1">
+                    <button className='btn btn-link' onClick={() => {
+                      this.loadModule(JSON.stringify(moduleEntry.module))
+                    }}>
+                      {moduleName} (Last saved: {moduleEntry.timestamp})
+                    </button>
+                  </div>
+                  <div className="flex-shrink-1 mx-5">
+                    <button className="close h-100 w-100" aria-label="Close" onClick={() => {
+                      removeLocalStorageModule(moduleName);
+                      this.updateLocalStorageModules();
+                    }}>
+                      <span aria-hidden="true">&times;</span>
+                    </button>
+                  </div>
                 </div>
               </li>
-            ))}
-          </ul>
-        </div>
+            );
+          })}
+        </ul>
       );
     default:
       return;
-
     }
   }
 

--- a/src/utils/localStorageHelpers.js
+++ b/src/utils/localStorageHelpers.js
@@ -21,7 +21,9 @@ export function getLocalStorageModules() {
 export function saveLocalStorageModule(module) {
   const newModuleObject = { ...getLocalStorageModules() };
 
-  newModuleObject[module.name] = module;
+  const timestamp = new Date().toLocaleString();
+
+  newModuleObject[module.name] = { module, timestamp };
 
   localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newModuleObject));
 }

--- a/src/utils/localStorageHelpers.js
+++ b/src/utils/localStorageHelpers.js
@@ -1,0 +1,43 @@
+const LOCAL_STORAGE_KEY = 'modules';
+
+/**
+ * Get any existing modules that exist in local storage
+ *
+ * @returns Object keyed by module name whose values are the module JSON
+ */
+export function getLocalStorageModules() {
+  const existingModules = localStorage.getItem(LOCAL_STORAGE_KEY);
+
+  if (!existingModules) return {};
+
+  return JSON.parse(existingModules);
+}
+
+/**
+ * Save a module to local storage
+ *
+ * @param {Object} module the JSON content of the module being saved
+ */
+export function saveLocalStorageModule(module) {
+  const newModuleObject = { ...getLocalStorageModules() };
+
+  newModuleObject[module.name] = module;
+
+  localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newModuleObject));
+}
+
+/**
+ * Delete a specific module from the object in localStorage
+ *
+ * @param {string} moduleName name of the module to remove
+ */
+export function removeLocalStorageModule(moduleName) {
+  const existingModules = getLocalStorageModules();
+
+  if (existingModules[moduleName]) {
+    const newModules = { ...existingModules };
+    delete newModules[moduleName];
+
+    localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newModules));
+  }
+}

--- a/src/utils/localStorageHelpers.js
+++ b/src/utils/localStorageHelpers.js
@@ -14,6 +14,18 @@ export function getLocalStorageModules() {
 }
 
 /**
+ * Get a module in local storage by name
+ *
+ * @param {string} moduleName name to lookup
+ * @returns matching entry in the modules object, or null if none found
+ */
+export function getLocalStorageModuleByName(moduleName) {
+  const allModules = getLocalStorageModules();
+
+  return allModules[moduleName] || null;
+}
+
+/**
  * Save a module to local storage
  *
  * @param {Object} module the JSON content of the module being saved


### PR DESCRIPTION
Solves #242
Solves #184 

This PR introduces logic that saves and loads modules from browser local storage

## New Behavior

When clicking the download button, there is a new button on the modal to save the module to local storage. When clicked, a message will pop up saying that the save was successful

The `Load Module` popup menu now has a section for `Local Storage` which contains any modules (keyed by name), that the user has saved to local storage. There is also a delete button to remove any unwanted modules

Any modules saved/removed/etc. should persist changes across refreshes of the app

## Open Questions

* Does the flow of this make sense? Should the save button live elsewhere other than the download modal?
* Should saving a module of the same name overwrite the existing entry, or create a copy with a different name?