### PR TITLE
Nested subfolders on GitHub Modules

### DIFF
--- a/src/components/menu/LoadModule.js
+++ b/src/components/menu/LoadModule.js
@@ -376,7 +376,7 @@ class LoadModule extends Component {
     return (
       <div>
         <div className={'modal ' +  classDetails} style={style}>
-            <div className="modal-content" style={{width:"900px", marginLeft: '15%', marginRight: '15%', marginTop: 50}}>
+            <div className="modal-content" style={{width:"1024px", marginLeft: '15%', marginRight: '15%', marginTop: 50}}>
               <div className="modal-header">
                 <h5 className="modal-title">{(!this.props.welcome ? 'Load Module' : 'Synthea Module Builder')}</h5>
                 <button type="button" className="close" data-dismiss="modal" aria-label="Close" onClick={this.props.onHide} style={{display: (this.props.welcome ? 'none' : '')}}>


### PR DESCRIPTION
Adds support for loading nested subfolders when loading via GitHub modules. (As an example, see the heart/cabg/ folder on the cabg_cardio_gmf branch)

The current approach keeps the previously hardcoded "modules" and "submodules" panels, and makes it so that nested subfolders overwrite the content of the submodules panel. I think this is a little bit of a hack, but it's quick and easy to implement. One other possibility would be to add additional columns to the right as the user navigates down the file tree, but that would require more rework. If people are interested, let me know and I will look more into that.

This also fixes the layout of the GitHub Modules overall panel, so that the submodules list doesn't spill over into a second row.