### PR TITLE
Vaccine State

### DIFF
--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -2500,6 +2500,8 @@ class Vaccine extends Component<Props> {
     return (
       <div>
         <div className='section'>
+          Series: <RIEInput className='editable-text' value={state.series} propName={'series'} change={this.props.onChange('series')} />
+          <br />
           Codes
           <br />
           <Codes codes={state.codes} system={"CVX"} onChange={this.props.onChange('codes')} />

--- a/src/components/editor/State.js
+++ b/src/components/editor/State.js
@@ -12,7 +12,8 @@ import type {
   CarePlanStartState, CarePlanEndState, ProcedureState,
   VitalSignState, ObservationState, MultiObservationState,
   DiagnosticReportState, ImagingStudyState, SymptomState,
-  SupplyListState, DeviceState, DeviceEndState, DeathState
+  SupplyListState, DeviceState, DeviceEndState, DeathState,
+  VaccineState
 } from '../../types/State';
 
 import { Code, Codes } from './Code';
@@ -122,6 +123,8 @@ class StateEditor extends Component<Props> {
         return <SupplyList {...props} />
       case "Death":
         return <Death {...props} />
+      case "Vaccine":
+        return  <Vaccine {...props} />
       default:
         return this.props.state.type
     }
@@ -2481,6 +2484,30 @@ class Procedure extends Component<Props> {
     this.setState({displayLabelReason: !this.state.displayLabelReason});
   }
 
+}
+
+class Vaccine extends Component<Props> {
+  constructor (props) {
+    super(props)
+  }
+
+  legacyGMF() {
+    let state = ((this.props.state: any): VaccineState);
+  }
+
+  render() {
+    let state = ((this.props.state: any): VaccineState);
+    return (
+      <div>
+        <div className='section'>
+          Codes
+          <br />
+          <Codes codes={state.codes} system={"CVX"} onChange={this.props.onChange('codes')} />
+          <br />
+        </div>
+      </div>
+    );
+  }
 }
 
 class VitalSign extends Component<Props> {

--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -88,6 +88,11 @@ const TypeTemplates = {
       system: "DICOM-SOP",
       code: "1.2.3.4.5.6.7.8",
       display: "DICOM Subject-Object Pair Code"
+    },
+    Cvx: {
+      system: "CVX",
+      code: "123",
+      display: "CVX Vaccine Code"
     }
   },
 
@@ -475,6 +480,11 @@ const StateTemplates = {
       }
     },
     "unit": "minutes"
+  },
+
+  Vaccine: {
+    type: "Vaccine",
+    codes: [{...TypeTemplates.Code.Cvx}]
   },
 
   VitalSign: {

--- a/src/templates/Templates.js
+++ b/src/templates/Templates.js
@@ -484,6 +484,7 @@ const StateTemplates = {
 
   Vaccine: {
     type: "Vaccine",
+    series: 1,
     codes: [{...TypeTemplates.Code.Cvx}]
   },
 

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -242,6 +242,7 @@ export type VaccineState = {
   name: string,
   remarks: string[],
   type: 'Vaccine',
+  series: number,
   codes: Code[],
   transition?: Transition
 }

--- a/src/types/State.js
+++ b/src/types/State.js
@@ -238,6 +238,14 @@ export type ProcedureState = {
   transition?: Transition
 }
 
+export type VaccineState = {
+  name: string,
+  remarks: string[],
+  type: 'Vaccine',
+  codes: Code[],
+  transition?: Transition
+}
+
 export type VitalSignState = {
   name: string,
   remarks: string[],
@@ -382,4 +390,4 @@ export type DeathState = {
   transition?: Transition
 }
 
-export type State = InitialState | TerminalState | SimpleState | GuardState | DelayState | SetAttributeState | CounterState | CallSubmoduleState | EncounterState | EncounterEndState | ConditionOnsetState | ConditionEndState | AllergyOnsetState | AllergyEndState | MedicationOrderState | MedicationEndState | CarePlanStartState | CarePlanEndState | ProcedureState | VitalSignState | ObservationState | MultiObservationState | DiagnosticReportState | SymptomState | DeathState;
+export type State = InitialState | TerminalState | SimpleState | GuardState | DelayState | SetAttributeState | CounterState | CallSubmoduleState | EncounterState | EncounterEndState | ConditionOnsetState | ConditionEndState | AllergyOnsetState | AllergyEndState | MedicationOrderState | MedicationEndState | CarePlanStartState | CarePlanEndState | ProcedureState | VitalSignState | ObservationState | MultiObservationState | DiagnosticReportState | SymptomState | DeathState | VaccineState;


### PR DESCRIPTION
This pull request adds a simple vaccine state to the Generic Module Framework (GMF) and the Module Builder. The state only takes one or more CVX codes. This state is mapped into Synthea via the `HealthRecord.Immunization` class, and later into FHIR into the `Immunization` resource.

![image](https://user-images.githubusercontent.com/1054765/153238908-a072341d-62b5-4030-9ffd-a13b0f7e7c7c.png)
