### PR TITLE
Fix graphviz error when changing symptom probability

### DIFF
--- a/src/utils/graphviz.js
+++ b/src/utils/graphviz.js
@@ -342,7 +342,7 @@ const stateDescription = (state) =>{
         let e = state['exact']
         details = `${s}: ${e['quantity']}`
       } else if (state['distribution'] !== undefined ) {
-        details = `${s}: ${distributionString(state['distribution'])}}`
+        details = `${s}: ${distributionString(state['distribution'])}`
       }
       if (p && p < 1.0 && p > 0) {
         let pct = p*100;


### PR DESCRIPTION
Just a one character change -- removes a mismatched close bracket on the Symptom graphviz renderer which was causing errors

Steps to reproduce issue:
1. Create new module
2. Create new state of type Symptom
3. Change the `probability` from `1` to something else, such as `0.5`
4. Previously it would crash, now it should render as expected