### PR TITLE
Update deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
-          node-version: '12.x'
-      - run: npm install
+          node-version: '20.x'
+      - run: npm install --legacy-peer-deps
       - run: npm run build
 
       - name: Deploy to gh-pages

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
           node-version: '20.x'
       - run: npm install --legacy-peer-deps
       - run: npm run build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@v3 


### PR DESCRIPTION
Updates the deploy workflow to prevent the error as seen in https://github.com/synthetichealth/module-builder/actions/runs/8379771158/job/22947474881

To be frank, I don't fully understand the error but it doesn't happen locally, so I upgraded the version of node used by the workflow from 12 (many years old now) to 20, and added the same two tweaks necessary to get it to run locally, ie, the `--legacy-peer-deps` flag as mentioned in #318 and an SSL env var to prevent an error in build.

This continues to be a bandage over very old versions of dependencies, but at least it's a quick update.